### PR TITLE
Post scientist fixes

### DIFF
--- a/geometries/limbangle/limbangle_algorithm.py
+++ b/geometries/limbangle/limbangle_algorithm.py
@@ -150,7 +150,7 @@ def boresight_for_difference(utc, target, galaxy_targ, reference_frame):
     frame, bsc_rf = sp.getfov(sp.namfrm(reference_frame), 4)[1:3]
 
     #btc convert bsc_rf to same frame (J2000) as bsc_aspera before subtraction
-    return bsc_aspera - sp.mxv(sp.pxform(reference_frame,ref,et),bsc_rf)
+    return sp.vhat(bsc_aspera) - sp.vhat(sp.mxv(sp.pxform(reference_frame,ref,et),bsc_rf))
 
 def get_fov(UTC, galaxy_targ):
     '''

--- a/geometries/quaternions/rotation_call.py
+++ b/geometries/quaternions/rotation_call.py
@@ -34,7 +34,8 @@ def main():
     tsclk = 8020944700000.0
     tqtr = [0.28490427, -0.46964652, 0.79148418, -0.26798229]
 
-    assert (sp.vnormg(sp.vsubg(qtr, tqtr, 4), 4) / sp.vnormg(qtr, 4)) < 1e-7
+    try   : assert (sp.vnormg(sp.vsubg(qtr, tqtr, 4), 4) / sp.vnormg(qtr, 4)) < 1e-7
+    except: assert (sp.vnormg(sp.vsubg(qtr, tqtr)) / sp.vnormg(qtr)) < 1e-7
     assert approx(sclk, rel=1e-14) == tsclk
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scientist says:
- Also, I have three things which I want the geometries team to fix. 
   - 1 ra_slit1/2, dec_slit1/2 
   - 2 OBSGEO - x/y/z needs geocentric terrestrial reference frame (ITRF). The current code obtain OBSGEO in J2000 frame. 
   - 3 BSC difference (ASP body and ASP_SLIT_1/2). Unsure of the intent. Also, the outputs are too large, ~10^16-10^17 in km.

Brian says:

* 1) RA and DEC of slit 1/2 were already calculated in **/geometries/slitradec/slitradec_algorithm.py**
* 2) I added the ITRF93 frame model and the algorithm uses that as the frame in which to calculate the S/C vector.
* 3) I changed this to be the difference in the unit vectors, instead of the meaningless difference between a unit vector (length 1.0; the boresight) and the vector to the galaxy (length is some number light-years).
